### PR TITLE
Add a snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: ghcal
+base: core18
+version: git
+summary: See the GitHub contributions calendar of a user in the command line
+description: |
+  See the GitHub contributions calendar of a user in the command line.
+  For example:
+    ghcal -u ionicabizau
+    ghcal -u ionicabizau --light
+    ghcal -u ionicabizau --no-ansi
+
+grade: stable
+confinement: strict
+
+parts:
+  ghcal:
+    plugin: nodejs
+    source: .
+
+apps:
+  ghcal:
+    command: ghcal
+    plugs: [home, network]


### PR DESCRIPTION
Hi Johnny B 👋 

ghcal is really cool, but I can't find it published anywhere discoverable. I work on Snapcraft, so I went ahead and created a snap of it. If you push to the Snap Store, millions of Linux users can [browse](https://snapcraft.io/store) their way to it.

To build, `snap install snapcraft` from Ubuntu, or `brew install snapcraft` on Mac, then run `snapcraft`.

To publish, [create an account](https://snapcraft.io/account), then:

```
snapcraft login
snapcraft register ghcal
snapcraft push --release=stable *.snap
```